### PR TITLE
在下拉刷新过程中如果狂点cell会出现闪退

### DIFF
--- a/LCFastBuildListKit/Classes/CollectionViewDelegateManager/ZLCollectionViewDelegateManager.m
+++ b/LCFastBuildListKit/Classes/CollectionViewDelegateManager/ZLCollectionViewDelegateManager.m
@@ -116,10 +116,12 @@
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
-    ZLCollectionViewSectionModel *sectionModel = self.datas[indexPath.section];
-    ZLCollectionViewRowModel *rowModel = sectionModel.items[indexPath.row];
-    if (self.delegate && [self.delegate respondsToSelector:@selector(didSelectRowAtModel:manager:indexPath:)]) {
-        [self.delegate didSelectRowAtModel:rowModel manager:self indexPath:indexPath];
+    if (self.datas && self.datas.count != 0) {
+        ZLCollectionViewSectionModel *sectionModel = self.datas[indexPath.section];
+        ZLCollectionViewRowModel *rowModel = sectionModel.items[indexPath.row];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(didSelectRowAtModel:manager:indexPath:)]) {
+            [self.delegate didSelectRowAtModel:rowModel manager:self indexPath:indexPath];
+        }
     }
 }
 

--- a/LCFastBuildListKit/Classes/TableViewDelegateManager/ZLTableViewDelegateManager.m
+++ b/LCFastBuildListKit/Classes/TableViewDelegateManager/ZLTableViewDelegateManager.m
@@ -113,10 +113,12 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    ZLTableViewSectionModel *sectionModel = self.datas[indexPath.section];
-    ZLTableViewRowModel *rowModel = sectionModel.items[indexPath.row];
-    if (self.delegate && [self.delegate respondsToSelector:@selector(didSelectRowAtModel:manager:indexPath:)]) {
-        [self.delegate didSelectRowAtModel:rowModel manager:self indexPath:indexPath];
+    if (self.datas && self.datas.count != 0) {
+        ZLTableViewSectionModel *sectionModel = self.datas[indexPath.section];
+        ZLTableViewRowModel *rowModel = sectionModel.items[indexPath.row];
+        if (self.delegate && [self.delegate respondsToSelector:@selector(didSelectRowAtModel:manager:indexPath:)]) {
+            [self.delegate didSelectRowAtModel:rowModel manager:self indexPath:indexPath];
+        }
     }
 }
 


### PR DESCRIPTION
下拉刷新时，外部清空了数据源，下拉刷新快结束时cell可以点击了，此时会走到库中的didSelect方法中,取self.datas[indexPath.section]时数组越界崩溃。加了个数组非空的判断你看下有没得问题